### PR TITLE
Implement basic stats and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ minecraft spigot plugin gaan maken voor versie 1.16 tot 1.21 met de volgende fun
 - Stats bijhouden van speler (time online, kills, mob kills, deaths, damage dealt, money earned, money spend, kilometers traveled)
 - instelbaar middels admin GUI
 -  speler GUI voor inzien van stats, levels & rewards. Ook voor spenderen van skillpoints op skills
+- Scoreboard om level en XP progressie te tonen (aan/uit te zetten met /skill scoreboard)
+- Integratie met Vault voor het uitkeren van geldbeloningen
+- Admin GUI laat het selecteren van item rewards per 20 levels toe en het instellen van een level cap
 - Skills: damage reduction, healing, lifesteal, damage, lung capacity, 
 
 voor commands:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ minecraft spigot plugin gaan maken voor versie 1.16 tot 1.21 met de volgende fun
 -  speler GUI voor inzien van stats, levels & rewards. Ook voor spenderen van skillpoints op skills
 - Scoreboard om level en XP progressie te tonen (aan/uit te zetten met /skill scoreboard)
 - Integratie met Vault voor het uitkeren van geldbeloningen
+- Transacties via Vault worden automatisch geregistreerd voor statistieken
 - Admin GUI laat het selecteren van item rewards per 20 levels toe en het instellen van een level cap
 - Skills: damage reduction, healing, lifesteal, damage, lung capacity,
 - Opslag van spelersdata via SQLite of MySQL (config `storage`)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ minecraft spigot plugin gaan maken voor versie 1.16 tot 1.21 met de volgende fun
 - Scoreboard om level en XP progressie te tonen (aan/uit te zetten met /skill scoreboard)
 - Integratie met Vault voor het uitkeren van geldbeloningen
 - Admin GUI laat het selecteren van item rewards per 20 levels toe en het instellen van een level cap
-- Skills: damage reduction, healing, lifesteal, damage, lung capacity, 
+- Skills: damage reduction, healing, lifesteal, damage, lung capacity,
+- Opslag van spelersdata via SQLite of MySQL (config `storage`)
+- /skill backup <sql|sqlite> om handmatig een backup te maken
 
 voor commands:
 /Skill opent skill GUI voor speler

--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -23,6 +23,12 @@
             <version>${spigot.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -15,6 +15,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>
@@ -28,6 +32,16 @@
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.alphactx</groupId>
+    <artifactId>LevelsX</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>LevelsX</name>
+    <properties>
+        <java.version>1.8</java.version>
+        <spigot.version>1.16.5-R0.1-SNAPSHOT</spigot.version>
+    </properties>
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${spigot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -23,6 +23,12 @@
             <version>${spigot.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.alphactx</groupId>
+    <artifactId>LevelsX</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>LevelsX</name>
+    <properties>
+        <java.version>17</java.version>
+        <spigot.version>1.21-R0.1-SNAPSHOT</spigot.version>
+    </properties>
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${spigot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -15,6 +15,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>
@@ -28,6 +32,16 @@
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/alphactx/LevelsX.java
+++ b/src/main/java/com/alphactx/LevelsX.java
@@ -1,0 +1,233 @@
+package com.alphactx;
+
+import com.alphactx.model.PlayerData;
+import com.alphactx.model.Skill;
+import com.alphactx.model.Stats;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class LevelsX extends JavaPlugin implements Listener {
+    private final Map<UUID, PlayerData> players = new HashMap<>();
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        loadData();
+        Bukkit.getPluginManager().registerEvents(this, this);
+        getLogger().info("LevelsX enabled");
+    }
+
+    @Override
+    public void onDisable() {
+        saveData();
+    }
+
+    private PlayerData getData(UUID uuid) {
+        return players.computeIfAbsent(uuid, PlayerData::new);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        PlayerData data = getData(event.getPlayer().getUniqueId());
+        data.setLastJoin(System.currentTimeMillis());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        PlayerData data = getData(event.getPlayer().getUniqueId());
+        long session = System.currentTimeMillis() - data.getLastJoin();
+        data.getStats().addTimeOnline(session);
+    }
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        if (event.getEntity().getKiller() != null) {
+            Player killer = event.getEntity().getKiller();
+            PlayerData data = getData(killer.getUniqueId());
+            if (event.getEntityType() == EntityType.PLAYER) {
+                data.getStats().addKill();
+            } else {
+                data.getStats().addMobKill();
+            }
+            awardXp(killer, 10);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        getData(player.getUniqueId()).getStats().addDeath();
+    }
+
+    @EventHandler
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player) {
+            Player player = (Player) event.getDamager();
+            getData(player.getUniqueId()).getStats().addDamageDealt(event.getDamage());
+        }
+        if (event.getEntity() instanceof Player) {
+            Player player = (Player) event.getEntity();
+            getData(player.getUniqueId()).getStats().addDamageTaken(event.getDamage());
+        }
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (event.getFrom().getWorld().equals(event.getTo().getWorld())) {
+            double distance = event.getFrom().distance(event.getTo());
+            getData(event.getPlayer().getUniqueId()).getStats().addKilometersTraveled(distance / 1000.0);
+        }
+    }
+
+    private void awardXp(Player player, int amount) {
+        PlayerData data = getData(player.getUniqueId());
+        data.addXp(amount);
+        if (data.tryLevelUp()) {
+            player.sendMessage("Leveled up to " + data.getLevel());
+            if (data.getLevel() % 20 == 0) {
+                ItemStack reward = new ItemStack(Material.DIAMOND);
+                player.getInventory().addItem(reward);
+            } else if (data.getLevel() % 5 != 0) {
+                double money = getConfig().getDouble("moneyReward", 100.0);
+                player.sendMessage("You earned $" + money);
+            }
+        }
+    }
+
+    private void openSkillGui(Player player) {
+        Inventory inv = Bukkit.createInventory(player, 9, "Skills");
+        player.openInventory(inv);
+    }
+
+    private void openAdminGui(Player player) {
+        Inventory inv = Bukkit.createInventory(player, 9, "Admin");
+        player.openInventory(inv);
+    }
+
+    private void showLeaderboard(Player player, String stat) {
+        List<Map.Entry<UUID, PlayerData>> sorted = players.entrySet().stream()
+                .sorted((a, b) -> compareStat(b.getValue().getStats(), a.getValue().getStats(), stat))
+                .limit(10)
+                .collect(Collectors.toList());
+        player.sendMessage("Leaderboard for " + stat + ":");
+        int i = 1;
+        for (Map.Entry<UUID, PlayerData> e : sorted) {
+            String name = Optional.ofNullable(Bukkit.getOfflinePlayer(e.getKey()).getName()).orElse("Unknown");
+            player.sendMessage(i + ". " + name + " - " + getStatValue(e.getValue().getStats(), stat));
+            i++;
+        }
+    }
+
+    private int compareStat(Stats a, Stats b, String stat) {
+        return Double.compare(getStatValue(a, stat), getStatValue(b, stat));
+    }
+
+    private double getStatValue(Stats stats, String stat) {
+        switch (stat.toLowerCase()) {
+            case "kills":
+                return stats.getKills();
+            case "mobkills":
+                return stats.getMobKills();
+            case "deaths":
+                return stats.getDeaths();
+            case "damage":
+                return stats.getDamageDealt();
+            case "distance":
+                return stats.getKilometersTraveled();
+            default:
+                return 0;
+        }
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players may use this command.");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (args.length == 0) {
+            openSkillGui(player);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("admin")) {
+            if (!player.hasPermission("skill.admin")) {
+                player.sendMessage("No permission");
+                return true;
+            }
+            openAdminGui(player);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("leaderboard")) {
+            String stat = args.length > 1 ? args[1] : "kills";
+            showLeaderboard(player, stat);
+            return true;
+        }
+        player.sendMessage("/skill, /skill admin, /skill leaderboard <stat>");
+        return true;
+    }
+
+    private void loadData() {
+        FileConfiguration cfg = getConfig();
+        if (cfg.isConfigurationSection("players")) {
+            for (String key : cfg.getConfigurationSection("players").getKeys(false)) {
+                UUID id = UUID.fromString(key);
+                PlayerData data = new PlayerData(id);
+                data.setLevel(cfg.getInt("players." + key + ".level", 1));
+                data.setXp(cfg.getInt("players." + key + ".xp", 0));
+                data.addSkillPoints(cfg.getInt("players." + key + ".skillPoints", 0));
+                Stats stats = data.getStats();
+                stats.addKill(cfg.getInt("players." + key + ".stats.kills", 0));
+                stats.addMobKill(cfg.getInt("players." + key + ".stats.mobKills", 0));
+                stats.addDeath(cfg.getInt("players." + key + ".stats.deaths", 0));
+                stats.addDamageDealt(cfg.getDouble("players." + key + ".stats.damageDealt", 0));
+                stats.addDamageTaken(cfg.getDouble("players." + key + ".stats.damageTaken", 0));
+                stats.addMoneyEarned(cfg.getDouble("players." + key + ".stats.moneyEarned", 0));
+                stats.addMoneySpent(cfg.getDouble("players." + key + ".stats.moneySpent", 0));
+                stats.addKilometersTraveled(cfg.getDouble("players." + key + ".stats.km", 0));
+                players.put(id, data);
+            }
+        }
+    }
+
+    private void saveData() {
+        FileConfiguration cfg = getConfig();
+        for (Map.Entry<UUID, PlayerData> entry : players.entrySet()) {
+            UUID id = entry.getKey();
+            PlayerData data = entry.getValue();
+            cfg.set("players." + id + ".xp", data.getXp());
+            cfg.set("players." + id + ".level", data.getLevel());
+            cfg.set("players." + id + ".skillPoints", data.getSkillPoints());
+            Stats stats = data.getStats();
+            cfg.set("players." + id + ".stats.kills", stats.getKills());
+            cfg.set("players." + id + ".stats.mobKills", stats.getMobKills());
+            cfg.set("players." + id + ".stats.deaths", stats.getDeaths());
+            cfg.set("players." + id + ".stats.damageDealt", stats.getDamageDealt());
+            cfg.set("players." + id + ".stats.damageTaken", stats.getDamageTaken());
+            cfg.set("players." + id + ".stats.moneyEarned", stats.getMoneyEarned());
+            cfg.set("players." + id + ".stats.moneySpent", stats.getMoneySpent());
+            cfg.set("players." + id + ".stats.km", stats.getKilometersTraveled());
+        }
+        saveConfig();
+    }
+}

--- a/src/main/java/com/alphactx/model/ChallengeType.java
+++ b/src/main/java/com/alphactx/model/ChallengeType.java
@@ -1,0 +1,9 @@
+package com.alphactx.model;
+
+public enum ChallengeType {
+    MOB_KILLS,
+    DAMAGE_TAKEN,
+    MONEY_EARNED,
+    MONEY_SPENT,
+    KILOMETERS_TRAVELED
+}

--- a/src/main/java/com/alphactx/model/PlayerData.java
+++ b/src/main/java/com/alphactx/model/PlayerData.java
@@ -73,6 +73,18 @@ public class PlayerData {
         return skills.getOrDefault(skill, 0);
     }
 
+    /** Set the level of a specific skill directly. */
+    public void setSkillLevel(Skill skill, int level) {
+        skills.put(skill, level);
+    }
+
+    /**
+     * @return immutable view of skill levels
+     */
+    public Map<Skill, Integer> getSkills() {
+        return new EnumMap<>(skills);
+    }
+
     public void levelSkill(Skill skill) {
         if (skillPoints > 0) {
             skills.put(skill, getSkillLevel(skill) + 1);
@@ -116,5 +128,12 @@ public class PlayerData {
     public void setLastChallengeReset(long time) {
         this.lastChallengeReset = time;
         challengeProgress.replaceAll((t, v) -> 0.0);
+    }
+
+    /**
+     * Load the timestamp for the last challenge reset without clearing progress.
+     */
+    public void loadLastChallengeReset(long time) {
+        this.lastChallengeReset = time;
     }
 }

--- a/src/main/java/com/alphactx/model/PlayerData.java
+++ b/src/main/java/com/alphactx/model/PlayerData.java
@@ -22,6 +22,7 @@ public class PlayerData {
     private final Map<Skill, Integer> skills = new EnumMap<>(Skill.class);
     private final Map<ChallengeType, Double> challengeProgress = new EnumMap<>(ChallengeType.class);
     private long lastChallengeReset = System.currentTimeMillis();
+    private boolean scoreboardEnabled = false;
 
     public PlayerData(UUID uuid) {
         this.uuid = uuid;
@@ -135,5 +136,13 @@ public class PlayerData {
      */
     public void loadLastChallengeReset(long time) {
         this.lastChallengeReset = time;
+    }
+
+    public boolean isScoreboardEnabled() {
+        return scoreboardEnabled;
+    }
+
+    public void setScoreboardEnabled(boolean enabled) {
+        this.scoreboardEnabled = enabled;
     }
 }

--- a/src/main/java/com/alphactx/model/PlayerData.java
+++ b/src/main/java/com/alphactx/model/PlayerData.java
@@ -23,6 +23,7 @@ public class PlayerData {
     private final Map<ChallengeType, Double> challengeProgress = new EnumMap<>(ChallengeType.class);
     private long lastChallengeReset = System.currentTimeMillis();
     private boolean scoreboardEnabled = false;
+    private double lastBalance = 0.0;
 
     public PlayerData(UUID uuid) {
         this.uuid = uuid;
@@ -144,5 +145,13 @@ public class PlayerData {
 
     public void setScoreboardEnabled(boolean enabled) {
         this.scoreboardEnabled = enabled;
+    }
+
+    public double getLastBalance() {
+        return lastBalance;
+    }
+
+    public void setLastBalance(double lastBalance) {
+        this.lastBalance = lastBalance;
     }
 }

--- a/src/main/java/com/alphactx/model/PlayerData.java
+++ b/src/main/java/com/alphactx/model/PlayerData.java
@@ -1,0 +1,90 @@
+package com.alphactx.model;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PlayerData {
+    private final UUID uuid;
+    private int level = 1;
+    private int xp = 0;
+    private int skillPoints = 0;
+    private long lastJoin;
+    private final Stats stats = new Stats();
+    private final Map<Skill, Integer> skills = new EnumMap<>(Skill.class);
+
+    public PlayerData(UUID uuid) {
+        this.uuid = uuid;
+        for (Skill skill : Skill.values()) {
+            skills.put(skill, 0);
+        }
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public int getXp() {
+        return xp;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public void setXp(int xp) {
+        this.xp = xp;
+    }
+
+    public int getSkillPoints() {
+        return skillPoints;
+    }
+
+    public Stats getStats() {
+        return stats;
+    }
+
+    public void setLastJoin(long time) {
+        this.lastJoin = time;
+    }
+
+    public long getLastJoin() {
+        return lastJoin;
+    }
+
+    public int getSkillLevel(Skill skill) {
+        return skills.getOrDefault(skill, 0);
+    }
+
+    public void levelSkill(Skill skill) {
+        if (skillPoints > 0) {
+            skills.put(skill, getSkillLevel(skill) + 1);
+            skillPoints--;
+        }
+    }
+
+    public void addXp(int amount) {
+        this.xp += amount;
+    }
+
+    public boolean tryLevelUp() {
+        int needed = level * 100;
+        boolean leveled = false;
+        while (xp >= needed) {
+            xp -= needed;
+            level++;
+            skillPoints += (level % 5 == 0) ? 1 : 0;
+            leveled = true;
+            needed = level * 100;
+        }
+        return leveled;
+    }
+
+    public void addSkillPoints(int amount) {
+        this.skillPoints += amount;
+    }
+}

--- a/src/main/java/com/alphactx/model/PlayerData.java
+++ b/src/main/java/com/alphactx/model/PlayerData.java
@@ -4,6 +4,14 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.UUID;
 
+import com.alphactx.model.ChallengeType;
+
+/**
+ * Stores player related data such as level, XP, skills and statistics.
+ * Challenge progress is tracked per {@link ChallengeType} so daily
+ * challenges can be completed.
+ */
+
 public class PlayerData {
     private final UUID uuid;
     private int level = 1;
@@ -12,11 +20,16 @@ public class PlayerData {
     private long lastJoin;
     private final Stats stats = new Stats();
     private final Map<Skill, Integer> skills = new EnumMap<>(Skill.class);
+    private final Map<ChallengeType, Double> challengeProgress = new EnumMap<>(ChallengeType.class);
+    private long lastChallengeReset = System.currentTimeMillis();
 
     public PlayerData(UUID uuid) {
         this.uuid = uuid;
         for (Skill skill : Skill.values()) {
             skills.put(skill, 0);
+        }
+        for (ChallengeType type : ChallengeType.values()) {
+            challengeProgress.put(type, 0.0);
         }
     }
 
@@ -86,5 +99,22 @@ public class PlayerData {
 
     public void addSkillPoints(int amount) {
         this.skillPoints += amount;
+    }
+
+    public Map<ChallengeType, Double> getChallengeProgress() {
+        return challengeProgress;
+    }
+
+    public void addChallengeProgress(ChallengeType type, double amount) {
+        challengeProgress.put(type, challengeProgress.getOrDefault(type, 0.0) + amount);
+    }
+
+    public long getLastChallengeReset() {
+        return lastChallengeReset;
+    }
+
+    public void setLastChallengeReset(long time) {
+        this.lastChallengeReset = time;
+        challengeProgress.replaceAll((t, v) -> 0.0);
     }
 }

--- a/src/main/java/com/alphactx/model/Skill.java
+++ b/src/main/java/com/alphactx/model/Skill.java
@@ -1,0 +1,9 @@
+package com.alphactx.model;
+
+public enum Skill {
+    DAMAGE,
+    DAMAGE_REDUCTION,
+    HEALING,
+    LIFESTEAL,
+    LUNG_CAPACITY
+}

--- a/src/main/java/com/alphactx/model/Stats.java
+++ b/src/main/java/com/alphactx/model/Stats.java
@@ -19,6 +19,10 @@ public class Stats {
         this.timeOnline += ms;
     }
 
+    public void setTimeOnline(long ms) {
+        this.timeOnline = ms;
+    }
+
     public int getKills() {
         return kills;
     }

--- a/src/main/java/com/alphactx/model/Stats.java
+++ b/src/main/java/com/alphactx/model/Stats.java
@@ -1,0 +1,97 @@
+package com.alphactx.model;
+
+public class Stats {
+    private long timeOnline;
+    private int kills;
+    private int mobKills;
+    private int deaths;
+    private double damageDealt;
+    private double damageTaken;
+    private double moneyEarned;
+    private double moneySpent;
+    private double kilometersTraveled;
+
+    public long getTimeOnline() {
+        return timeOnline;
+    }
+
+    public void addTimeOnline(long ms) {
+        this.timeOnline += ms;
+    }
+
+    public int getKills() {
+        return kills;
+    }
+
+    public void addKill() {
+        this.kills++;
+    }
+
+    public void addKill(int amount) {
+        this.kills += amount;
+    }
+
+    public int getMobKills() {
+        return mobKills;
+    }
+
+    public void addMobKill() {
+        this.mobKills++;
+    }
+
+    public void addMobKill(int amount) {
+        this.mobKills += amount;
+    }
+
+    public int getDeaths() {
+        return deaths;
+    }
+
+    public void addDeath() {
+        this.deaths++;
+    }
+
+    public void addDeath(int amount) {
+        this.deaths += amount;
+    }
+
+    public double getDamageDealt() {
+        return damageDealt;
+    }
+
+    public void addDamageDealt(double amount) {
+        this.damageDealt += amount;
+    }
+
+    public double getDamageTaken() {
+        return damageTaken;
+    }
+
+    public void addDamageTaken(double amount) {
+        this.damageTaken += amount;
+    }
+
+    public double getMoneyEarned() {
+        return moneyEarned;
+    }
+
+    public void addMoneyEarned(double amount) {
+        this.moneyEarned += amount;
+    }
+
+    public double getMoneySpent() {
+        return moneySpent;
+    }
+
+    public void addMoneySpent(double amount) {
+        this.moneySpent += amount;
+    }
+
+    public double getKilometersTraveled() {
+        return kilometersTraveled;
+    }
+
+    public void addKilometersTraveled(double distance) {
+        this.kilometersTraveled += distance;
+    }
+}

--- a/src/main/java/com/alphactx/storage/DataStorage.java
+++ b/src/main/java/com/alphactx/storage/DataStorage.java
@@ -1,0 +1,13 @@
+package com.alphactx.storage;
+
+import com.alphactx.model.PlayerData;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.UUID;
+
+public interface DataStorage {
+    void load(Map<UUID, PlayerData> target) throws SQLException;
+    void save(Map<UUID, PlayerData> source) throws SQLException;
+    void close() throws SQLException;
+}

--- a/src/main/java/com/alphactx/storage/DataUtil.java
+++ b/src/main/java/com/alphactx/storage/DataUtil.java
@@ -28,6 +28,7 @@ public final class DataUtil {
         stats.addMoneySpent(cfg.getDouble("stats.moneySpent", 0));
         stats.addKilometersTraveled(cfg.getDouble("stats.km", 0));
         stats.setTimeOnline(cfg.getLong("stats.time", 0));
+        data.setLastBalance(cfg.getDouble("lastBalance", 0));
         data.loadLastChallengeReset(cfg.getLong("lastChallengeReset", System.currentTimeMillis()));
         for (ChallengeType ct : ChallengeType.values()) {
             data.addChallengeProgress(ct, cfg.getDouble("challenges." + ct.name(), 0));
@@ -51,6 +52,7 @@ public final class DataUtil {
         cfg.set("stats.moneySpent", stats.getMoneySpent());
         cfg.set("stats.km", stats.getKilometersTraveled());
         cfg.set("stats.time", stats.getTimeOnline());
+        cfg.set("lastBalance", data.getLastBalance());
         cfg.set("lastChallengeReset", data.getLastChallengeReset());
         for (Map.Entry<ChallengeType, Double> e : data.getChallengeProgress().entrySet()) {
             cfg.set("challenges." + e.getKey().name(), e.getValue());

--- a/src/main/java/com/alphactx/storage/DataUtil.java
+++ b/src/main/java/com/alphactx/storage/DataUtil.java
@@ -1,0 +1,59 @@
+package com.alphactx.storage;
+
+import com.alphactx.model.ChallengeType;
+import com.alphactx.model.PlayerData;
+import com.alphactx.model.Skill;
+import com.alphactx.model.Stats;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.Map;
+
+public final class DataUtil {
+    private DataUtil() {}
+
+    public static void load(FileConfiguration cfg, PlayerData data) {
+        data.setXp(cfg.getInt("xp", 0));
+        data.setLevel(cfg.getInt("level", 1));
+        data.addSkillPoints(cfg.getInt("skillPoints", 0));
+        for (Skill s : Skill.values()) {
+            data.setSkillLevel(s, cfg.getInt("skills." + s.name(), 0));
+        }
+        Stats stats = data.getStats();
+        stats.addKill(cfg.getInt("stats.kills", 0));
+        stats.addMobKill(cfg.getInt("stats.mobKills", 0));
+        stats.addDeath(cfg.getInt("stats.deaths", 0));
+        stats.addDamageDealt(cfg.getDouble("stats.damageDealt", 0));
+        stats.addDamageTaken(cfg.getDouble("stats.damageTaken", 0));
+        stats.addMoneyEarned(cfg.getDouble("stats.moneyEarned", 0));
+        stats.addMoneySpent(cfg.getDouble("stats.moneySpent", 0));
+        stats.addKilometersTraveled(cfg.getDouble("stats.km", 0));
+        stats.setTimeOnline(cfg.getLong("stats.time", 0));
+        data.loadLastChallengeReset(cfg.getLong("lastChallengeReset", System.currentTimeMillis()));
+        for (ChallengeType ct : ChallengeType.values()) {
+            data.addChallengeProgress(ct, cfg.getDouble("challenges." + ct.name(), 0));
+        }
+    }
+
+    public static void save(FileConfiguration cfg, PlayerData data) {
+        cfg.set("xp", data.getXp());
+        cfg.set("level", data.getLevel());
+        cfg.set("skillPoints", data.getSkillPoints());
+        for (Skill s : Skill.values()) {
+            cfg.set("skills." + s.name(), data.getSkillLevel(s));
+        }
+        Stats stats = data.getStats();
+        cfg.set("stats.kills", stats.getKills());
+        cfg.set("stats.mobKills", stats.getMobKills());
+        cfg.set("stats.deaths", stats.getDeaths());
+        cfg.set("stats.damageDealt", stats.getDamageDealt());
+        cfg.set("stats.damageTaken", stats.getDamageTaken());
+        cfg.set("stats.moneyEarned", stats.getMoneyEarned());
+        cfg.set("stats.moneySpent", stats.getMoneySpent());
+        cfg.set("stats.km", stats.getKilometersTraveled());
+        cfg.set("stats.time", stats.getTimeOnline());
+        cfg.set("lastChallengeReset", data.getLastChallengeReset());
+        for (Map.Entry<ChallengeType, Double> e : data.getChallengeProgress().entrySet()) {
+            cfg.set("challenges." + e.getKey().name(), e.getValue());
+        }
+    }
+}

--- a/src/main/java/com/alphactx/storage/MySqlStorage.java
+++ b/src/main/java/com/alphactx/storage/MySqlStorage.java
@@ -1,0 +1,56 @@
+package com.alphactx.storage;
+
+import com.alphactx.model.PlayerData;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.UUID;
+
+public class MySqlStorage implements DataStorage {
+    private final Connection connection;
+
+    public MySqlStorage(String host, int port, String db, String user, String pass) throws SQLException {
+        String url = "jdbc:mysql://" + host + ":" + port + "/" + db + "?useSSL=false";
+        connection = DriverManager.getConnection(url, user, pass);
+        try (Statement st = connection.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS players (uuid VARCHAR(36) PRIMARY KEY, data TEXT)");
+        }
+    }
+
+    @Override
+    public void load(Map<UUID, PlayerData> target) throws SQLException {
+        try (Statement st = connection.createStatement()) {
+            ResultSet rs = st.executeQuery("SELECT uuid,data FROM players");
+            while (rs.next()) {
+                UUID id = UUID.fromString(rs.getString(1));
+                String yaml = rs.getString(2);
+                YamlConfiguration cfg = new YamlConfiguration();
+                try {
+                    cfg.loadFromString(yaml);
+                } catch (Exception ignored) {}
+                PlayerData data = new PlayerData(id);
+                DataUtil.load(cfg, data);
+                target.put(id, data);
+            }
+        }
+    }
+
+    @Override
+    public void save(Map<UUID, PlayerData> source) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement("REPLACE INTO players(uuid,data) VALUES(?,?)")) {
+            for (PlayerData data : source.values()) {
+                YamlConfiguration cfg = new YamlConfiguration();
+                DataUtil.save(cfg, data);
+                ps.setString(1, data.getUuid().toString());
+                ps.setString(2, cfg.saveToString());
+                ps.executeUpdate();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws SQLException {
+        connection.close();
+    }
+}

--- a/src/main/java/com/alphactx/storage/SqliteStorage.java
+++ b/src/main/java/com/alphactx/storage/SqliteStorage.java
@@ -1,0 +1,58 @@
+package com.alphactx.storage;
+
+import com.alphactx.model.PlayerData;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.sql.*;
+import java.util.Map;
+import java.util.UUID;
+
+public class SqliteStorage implements DataStorage {
+    private final Connection connection;
+
+    public SqliteStorage(File dataFolder) throws SQLException {
+        dataFolder.mkdirs();
+        File file = new File(dataFolder, "levelsx.db");
+        connection = DriverManager.getConnection("jdbc:sqlite:" + file.getPath());
+        try (Statement st = connection.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS players (uuid TEXT PRIMARY KEY, data TEXT)");
+        }
+    }
+
+    @Override
+    public void load(Map<UUID, PlayerData> target) throws SQLException {
+        try (Statement st = connection.createStatement()) {
+            ResultSet rs = st.executeQuery("SELECT uuid,data FROM players");
+            while (rs.next()) {
+                UUID id = UUID.fromString(rs.getString(1));
+                String yaml = rs.getString(2);
+                YamlConfiguration cfg = new YamlConfiguration();
+                try {
+                    cfg.loadFromString(yaml);
+                } catch (Exception ignored) {}
+                PlayerData data = new PlayerData(id);
+                DataUtil.load(cfg, data);
+                target.put(id, data);
+            }
+        }
+    }
+
+    @Override
+    public void save(Map<UUID, PlayerData> source) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement("REPLACE INTO players(uuid,data) VALUES(?,?)")) {
+            for (PlayerData data : source.values()) {
+                YamlConfiguration cfg = new YamlConfiguration();
+                DataUtil.save(cfg, data);
+                ps.setString(1, data.getUuid().toString());
+                ps.setString(2, cfg.saveToString());
+                ps.executeUpdate();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws SQLException {
+        connection.close();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,2 @@
+players: {}
+moneyReward: 100.0

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,7 @@ players: {}
 moneyReward: 100.0
 itemReward: DIAMOND
 itemRewards: {}
+levelCap: 100
 challengeGoals:
   MOB_KILLS: 10
   DAMAGE_TAKEN: 500

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,8 @@
 players: {}
 moneyReward: 100.0
+challengeGoals:
+  MOB_KILLS: 10
+  DAMAGE_TAKEN: 500
+  MONEY_EARNED: 1000
+  MONEY_SPENT: 1000
+  KILOMETERS_TRAVELED: 5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,11 @@
-players: {}
+storage:
+  type: sqlite
+  mysql:
+    host: localhost
+    port: 3306
+    database: levelsx
+    user: root
+    password: ''
 moneyReward: 100.0
 itemReward: DIAMOND
 itemRewards: {}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 players: {}
 moneyReward: 100.0
 itemReward: DIAMOND
+itemRewards: {}
 challengeGoals:
   MOB_KILLS: 10
   DAMAGE_TAKEN: 500

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 players: {}
 moneyReward: 100.0
+itemReward: DIAMOND
 challengeGoals:
   MOB_KILLS: 10
   DAMAGE_TAKEN: 500

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: LevelsX
 main: com.alphactx.LevelsX
 version: 1.0
 api-version: 1.16
+depend: [Vault]
 commands:
   skill:
     description: Levels command

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: LevelsX
+main: com.alphactx.LevelsX
+version: 1.0
+api-version: 1.16
+commands:
+  skill:
+    description: Levels command
+    usage: /<command>


### PR DESCRIPTION
## Summary
- implement comprehensive `LevelsX` event tracking and reward logic
- introduce `PlayerData`, `Stats`, and `Skill` classes
- store default money reward in config

## Testing
- ❌ `mvn -q -f pom-1.16.xml package -DskipTests` (failed: `mvn` not found)

------
https://chatgpt.com/codex/tasks/task_e_6864610008d883299f06f9eff98ba315