### PR TITLE
Implement persistent scoreboard and weekly challenges

### DIFF
--- a/src/main/java/com/alphactx/model/PlayerData.java
+++ b/src/main/java/com/alphactx/model/PlayerData.java
@@ -20,8 +20,10 @@ public class PlayerData {
     private long lastJoin;
     private final Stats stats = new Stats();
     private final Map<Skill, Integer> skills = new EnumMap<>(Skill.class);
-    private final Map<ChallengeType, Double> challengeProgress = new EnumMap<>(ChallengeType.class);
-    private long lastChallengeReset = System.currentTimeMillis();
+    private final Map<ChallengeType, Double> dailyProgress = new EnumMap<>(ChallengeType.class);
+    private final Map<ChallengeType, Double> weeklyProgress = new EnumMap<>(ChallengeType.class);
+    private long lastDailyReset = System.currentTimeMillis();
+    private long lastWeeklyReset = System.currentTimeMillis();
     private boolean scoreboardEnabled = false;
     private double lastBalance = 0.0;
 
@@ -31,7 +33,8 @@ public class PlayerData {
             skills.put(skill, 0);
         }
         for (ChallengeType type : ChallengeType.values()) {
-            challengeProgress.put(type, 0.0);
+            dailyProgress.put(type, 0.0);
+            weeklyProgress.put(type, 0.0);
         }
     }
 
@@ -115,28 +118,46 @@ public class PlayerData {
         this.skillPoints += amount;
     }
 
-    public Map<ChallengeType, Double> getChallengeProgress() {
-        return challengeProgress;
+    public Map<ChallengeType, Double> getDailyProgress() {
+        return dailyProgress;
     }
 
-    public void addChallengeProgress(ChallengeType type, double amount) {
-        challengeProgress.put(type, challengeProgress.getOrDefault(type, 0.0) + amount);
+    public Map<ChallengeType, Double> getWeeklyProgress() {
+        return weeklyProgress;
     }
 
-    public long getLastChallengeReset() {
-        return lastChallengeReset;
+    public void addDailyProgress(ChallengeType type, double amount) {
+        dailyProgress.put(type, dailyProgress.getOrDefault(type, 0.0) + amount);
     }
 
-    public void setLastChallengeReset(long time) {
-        this.lastChallengeReset = time;
-        challengeProgress.replaceAll((t, v) -> 0.0);
+    public void addWeeklyProgress(ChallengeType type, double amount) {
+        weeklyProgress.put(type, weeklyProgress.getOrDefault(type, 0.0) + amount);
     }
 
-    /**
-     * Load the timestamp for the last challenge reset without clearing progress.
-     */
-    public void loadLastChallengeReset(long time) {
-        this.lastChallengeReset = time;
+    public long getLastDailyReset() {
+        return lastDailyReset;
+    }
+
+    public void setLastDailyReset(long time) {
+        this.lastDailyReset = time;
+        dailyProgress.replaceAll((t, v) -> 0.0);
+    }
+
+    public void loadLastDailyReset(long time) {
+        this.lastDailyReset = time;
+    }
+
+    public long getLastWeeklyReset() {
+        return lastWeeklyReset;
+    }
+
+    public void setLastWeeklyReset(long time) {
+        this.lastWeeklyReset = time;
+        weeklyProgress.replaceAll((t, v) -> 0.0);
+    }
+
+    public void loadLastWeeklyReset(long time) {
+        this.lastWeeklyReset = time;
     }
 
     public boolean isScoreboardEnabled() {

--- a/src/main/java/com/alphactx/storage/DataUtil.java
+++ b/src/main/java/com/alphactx/storage/DataUtil.java
@@ -29,9 +29,12 @@ public final class DataUtil {
         stats.addKilometersTraveled(cfg.getDouble("stats.km", 0));
         stats.setTimeOnline(cfg.getLong("stats.time", 0));
         data.setLastBalance(cfg.getDouble("lastBalance", 0));
-        data.loadLastChallengeReset(cfg.getLong("lastChallengeReset", System.currentTimeMillis()));
+        data.setScoreboardEnabled(cfg.getBoolean("scoreboardEnabled", false));
+        data.loadLastDailyReset(cfg.getLong("lastDailyReset", System.currentTimeMillis()));
+        data.loadLastWeeklyReset(cfg.getLong("lastWeeklyReset", System.currentTimeMillis()));
         for (ChallengeType ct : ChallengeType.values()) {
-            data.addChallengeProgress(ct, cfg.getDouble("challenges." + ct.name(), 0));
+            data.addDailyProgress(ct, cfg.getDouble("daily." + ct.name(), 0));
+            data.addWeeklyProgress(ct, cfg.getDouble("weekly." + ct.name(), 0));
         }
     }
 
@@ -53,9 +56,14 @@ public final class DataUtil {
         cfg.set("stats.km", stats.getKilometersTraveled());
         cfg.set("stats.time", stats.getTimeOnline());
         cfg.set("lastBalance", data.getLastBalance());
-        cfg.set("lastChallengeReset", data.getLastChallengeReset());
-        for (Map.Entry<ChallengeType, Double> e : data.getChallengeProgress().entrySet()) {
-            cfg.set("challenges." + e.getKey().name(), e.getValue());
+        cfg.set("scoreboardEnabled", data.isScoreboardEnabled());
+        cfg.set("lastDailyReset", data.getLastDailyReset());
+        cfg.set("lastWeeklyReset", data.getLastWeeklyReset());
+        for (Map.Entry<ChallengeType, Double> e : data.getDailyProgress().entrySet()) {
+            cfg.set("daily." + e.getKey().name(), e.getValue());
+        }
+        for (Map.Entry<ChallengeType, Double> e : data.getWeeklyProgress().entrySet()) {
+            cfg.set("weekly." + e.getKey().name(), e.getValue());
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,3 +32,24 @@ challengeGoals:
   MONEY_EARNED: 1000  # Amount of money to earn
   MONEY_SPENT: 1000  # Amount of money to spend
   KILOMETERS_TRAVELED: 5     # Distance to travel in kilometers
+
+# --- Challenge Rewards ---
+# Rewards granted when completing challenges
+challengeRewards:
+  daily:
+    xp: 20
+    money: 0.0
+  weekly:
+    xp: 50
+    money: 0.0
+
+# --- Kill Rewards ---
+killRewards:
+  mobs:
+    enabled: true
+    xp: 10
+    money: 0.0
+  players:
+    enabled: true
+    xp: 25
+    money: 0.0


### PR DESCRIPTION
## Summary
- persist scoreboard toggle state in player data
- add daily and weekly challenge rotation
- store progress for daily and weekly challenges separately
- allow admin item rewards beyond level 100 based on level cap

## Testing
- `mvn -q -f pom-1.16.xml -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68650765fff08329902c8410b68b5d4e