### PR TITLE
Remove chat prefix from normal messages

### DIFF
--- a/src/main/java/com/alphactx/LevelsX.java
+++ b/src/main/java/com/alphactx/LevelsX.java
@@ -164,10 +164,8 @@ public class LevelsX extends JavaPlugin implements Listener, TabCompleter {
         data.setLastBalance(current);
     }
 
-    @EventHandler
-    public void onChat(AsyncPlayerChatEvent event) {
-        event.setFormat(ChatColor.GOLD + "[LevelsX] " + ChatColor.RESET + "%s: %s");
-    }
+
+    // Removed chat formatting override so normal player chat is unaffected
 
     @EventHandler
     public void onEntityDeath(EntityDeathEvent event) {


### PR DESCRIPTION
## Summary
- stop overriding regular chat messages with `[LevelsX]` prefix

## Testing
- `mvn -q -DskipTests -f pom-1.16.xml package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6866b99995a0832993ffddc0256c3cc8