### PR TITLE
Improve scoreboard settings in Config GUI

### DIFF
--- a/src/main/java/com/alphactx/LevelsX.java
+++ b/src/main/java/com/alphactx/LevelsX.java
@@ -380,8 +380,8 @@ public class LevelsX extends JavaPlugin implements Listener, TabCompleter {
             ChallengeType type = ChallengeType.valueOf(title.substring(10));
             String base = "challengeRewards.";
             if (slot == 0 || slot == 1 || slot == 3 || slot == 4) {
-                String key = slot<2? "daily" : "weekly";
-                String sub  = slot%2==0? "xp" : "money";
+                String key = slot < 2 ? "daily" : "weekly";
+                String sub  = (slot == 0 || slot == 3) ? "xp" : "money";
                 int delta = click.isShiftClick()?10:1;
                 if (click==ClickType.LEFT) delta = -delta;
                 String path = base + key + (slot<2? ".types."+type.name() : ".types."+type.name()) + "." + sub;

--- a/src/main/java/com/alphactx/LevelsX.java
+++ b/src/main/java/com/alphactx/LevelsX.java
@@ -413,7 +413,7 @@ public class LevelsX extends JavaPlugin implements Listener, TabCompleter {
             if (slot==0 || slot==1 || slot==3 || slot==4) {
                 boolean isXP = (slot==0 || slot==3);
                 String path = slot<2? "killRewards.players." : "killRewards.mobs.";
-                String sub = (slot%2==0? "xp" : "money");
+                String sub = isXP ? "xp" : "money";
                 int delta = click.isShiftClick()?10:1;
                 if (click==ClickType.LEFT) delta = -delta;
                 if (isXP) {


### PR DESCRIPTION
## Summary
- link Config -> Scoreboard settings GUI
- add Kills, Mob Kills, Deaths and KM to scoreboard
- update scoreboard dynamically for new stats
- refresh scoreboard when kills or deaths happen

## Testing
- `mvn -q -f pom-1.21.xml test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6866c491eb0c8329ba6210bf3300dd74