### PR TITLE
Add PlaceholderAPI and bStats integrations

### DIFF
--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -34,6 +34,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.45.1.0</version>

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -34,6 +34,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.45.1.0</version>

--- a/src/main/java/com/alphactx/LevelsX.java
+++ b/src/main/java/com/alphactx/LevelsX.java
@@ -8,6 +8,7 @@ import com.alphactx.model.ScoreField;
 import com.alphactx.storage.DataStorage;
 import com.alphactx.storage.SqliteStorage;
 import com.alphactx.storage.MySqlStorage;
+import org.bstats.bukkit.Metrics;
 
 import net.milkbowl.vault.economy.Economy;
 
@@ -118,6 +119,12 @@ public class LevelsX extends JavaPlugin implements Listener, TabCompleter {
         int minutes = Math.max(1, getConfig().getInt("autosave", 5));
         autosaveTask = Bukkit.getScheduler()
             .scheduleSyncRepeatingTask(this, this::saveData, 20L*60*minutes, 20L*60*minutes);
+        // Start bStats metrics
+        new Metrics(this, 26371);
+        // Register PlaceholderAPI expansion if available
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new LevelsXExpansion(this).register();
+        }
         getLogger().info("LevelsX enabled");
     }
 
@@ -131,6 +138,13 @@ public class LevelsX extends JavaPlugin implements Listener, TabCompleter {
 
     private PlayerData getData(UUID uuid) {
         return players.computeIfAbsent(uuid, PlayerData::new);
+    }
+
+    /**
+     * Public accessor for other integrations.
+     */
+    public PlayerData getPlayerData(UUID uuid) {
+        return getData(uuid);
     }
 
     // === Events ===

--- a/src/main/java/com/alphactx/LevelsXExpansion.java
+++ b/src/main/java/com/alphactx/LevelsXExpansion.java
@@ -1,0 +1,62 @@
+package com.alphactx;
+
+import com.alphactx.model.PlayerData;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * PlaceholderAPI expansion for LevelsX.
+ */
+public class LevelsXExpansion extends PlaceholderExpansion {
+
+    private final LevelsX plugin;
+
+    public LevelsXExpansion(LevelsX plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "levelsx";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "AlphaCtx";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String params) {
+        if (player == null) return "";
+        PlayerData data = plugin.getPlayerData(player.getUniqueId());
+        switch (params.toLowerCase()) {
+            case "level":
+                return String.valueOf(data.getLevel());
+            case "xp":
+                return String.valueOf(data.getXp());
+            case "skillpoints":
+                return String.valueOf(data.getSkillPoints());
+            case "kills":
+                return String.valueOf(data.getStats().getKills());
+            case "mobkills":
+                return String.valueOf(data.getStats().getMobKills());
+            case "deaths":
+                return String.valueOf(data.getStats().getDeaths());
+            case "progress":
+                return data.getXp() + "/" + (data.getLevel() * 100);
+            default:
+                return "";
+        }
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: com.alphactx.LevelsX
 version: 1.0
 api-version: 1.16
 depend: [Vault]
+softdepend: [PlaceholderAPI]
 commands:
   skill:
     description: Levels command


### PR DESCRIPTION
## Summary
- integrate bStats with plugin id 26371
- hook PlaceholderAPI when available and expose placeholders
- expose player data for integrations
- declare new softdepend and dependencies

## Testing
- `mvn -f pom-1.21.xml package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867c0ec98e883299d2d54be1c4ba7ae